### PR TITLE
Player Pan w/ LOS Logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,39 @@
 # Next-Up
 
-This module will auto focus on the current combatants token at the start of their turn, and pull up its specific actor sheet (only for the GM).
-It can close the previous combatants sheet or all opened character sheets
+Have you even lost yourself in the mire of 8 actor sheets open at 1 time?
+ Do you ever loose track of which mage has spell slots left?
+Do you ever run large combats and take 5 seconds each round to find the currently acting token?
+
+### Well Next Up is for you!
+
+This module can:
+- Auto focus on the current combatants token at the start of their turn (client setting)
+- Pull up its specific actor sheet for the GM.
+- Close the previous combatants sheet or all opened character sheets to remove clutter
+- Pin specific sheets to the ui to prevent them being closed
 
 ![Combat Focus 1](https://github.com/kandashi/Next-Up/blob/main/Images/auto%20focus.gif?raw=true)
 
 ![Combat Focus 2](https://github.com/kandashi/Next-Up/blob/main/Images/auto%20focus%202.gif?raw=true)
 
+## Settings
+### Sheet Postion
+-Where in the ui to open the actor sheet is opened
 
+### Which Actor Sheet Types To Open
+- Chooses which types of actor's sheets should be opened, choose from All, Unlinked, or Non-Owned
 
-## Upcoming features
-- Ability to "pin" actor sheets to prevent closing
+### Which Combatant Sheets to Close
+- Out of the currently open actor sheets, which should be closed when combat moves on. Choose from: none; only previous combatant, and all sheets.
+
+### Which Actor Sheet Types To Close
+- Which types of actor sheets should be automaticly closed, filtering from previous settings. Choose from: only unlinked tokens; only linked tokens; all tokens
+
+### Enable Panning For Player Clients
+- GM side settings to allow players to enable panning on their clients. Players will only pan to tokens they have line of sight too
+
+### Pan To Next Combatant
+- Client side setting to pan to next combatant. GM will pan to every token, players will only pan to those in line of sight.
+
+### Remove Pin Icon From Character Sheets
+- Setting to remove the ability to pin character sheets. 

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
     "name": "Next-Up",
     "title": "Next Up",
     "description": "Auto focus to current combatant for GM clients",
-    "version": "0.0.32",
+    "version": "0.0.33",
     "authors": [
       {
         "name": "Kandashi",

--- a/src/combatFocus.js
+++ b/src/combatFocus.js
@@ -1,12 +1,5 @@
 Hooks.on('init', () => {
-    game.settings.register("Next-Up", "combatPan", {
-        name: 'Pan To Combatant',
-        hint: 'Auto focuses to the current combatant ',
-        scope: 'world',
-        type: Boolean,
-        default: true,
-        config: true,
-    });
+   
     game.settings.register("Next-Up", "combatFocusPostion", {
         name: 'Sheet Position',
         hint: 'Postion Of The Opened Character Sheet',
@@ -57,9 +50,17 @@ Hooks.on('init', () => {
         default: "0",
         config: true,
     });
+    game.settings.register("Next-Up", "playerPanEnable", {
+        name: 'Enable Panning For Player Clients',
+        hint: "Enables player clients to pan to tokens they have line of sight too. Requires clients to enable on their side",
+        scope: 'world', 
+        type: Boolean,
+        default: false,
+        config: true,
+    });
     game.settings.register("Next-Up", "playerPan", {
-        name: 'Pan Players to Combatant',
-        scope: 'world', // could be client scope too
+        name: 'Pan To Next Combatant',
+        scope: 'client', 
         type: Boolean,
         default: false,
         config: true,
@@ -107,11 +108,11 @@ Hooks.on("updateCombat", async (combat, changed, options, userId) => {
     if (game.combats.get(combat.id).data.combatants.length == 0) return;
 
     const combatFocusPostion = game.settings.get('Next-Up', 'combatFocusPostion');
-    const combatFocusPan = game.settings.get('Next-Up', 'combatPan');
+    const playerPanEnable = game.settings.get('Next-Up', 'playerPanEnable');
+    const playerPan = game.settings.get('Next-Up', 'playerPan');
     const closeWhich = game.settings.get('Next-Up', 'closewhich');
     const closeType = game.settings.get('Next-Up', 'closetype');
     const combatFocusType = game.settings.get('Next-Up', 'combatFocusType');
-    const playerPan = game.settings.get('Next-Up', 'playerPan');
     let currentWindows = Object.values(ui.windows);
 
     let nextTurn = combat.turns[changed.turn];
@@ -140,7 +141,6 @@ Hooks.on("updateCombat", async (combat, changed, options, userId) => {
     if (firstGm && game.user === firstGm) {
 
         await currentToken.control();
-        if (combatFocusPan) canvas.animatePan({ x: currentToken.center.x, y: currentToken.center.y, duration: 250 });
 
         if (combatFocusPostion !== "0") {
             let currentSheet = currentWindows.filter(i => i.token?.id === currentToken.id);
@@ -186,7 +186,7 @@ Hooks.on("updateCombat", async (combat, changed, options, userId) => {
         }
     }
 
-    if (!game.user.isGM && playerPan && combatFocusPan && currentToken.isVisible) {
+    if (playerPanEnable &&  playerPan && (currentToken.isVisible || game.user === firstGm)) {
         canvas.animatePan({ x: currentToken.center.x, y: currentToken.center.y, duration: 250 });
     }
 

--- a/src/combatFocus.js
+++ b/src/combatFocus.js
@@ -136,10 +136,10 @@ Hooks.on("updateCombat", async (combat, changed, options, userId) => {
 
 
     await sleep(delay);
-    await currentToken.control();
     const firstGm = game.users.find((u) => u.isGM && u.active);
     if (firstGm && game.user === firstGm) {
 
+        await currentToken.control();
         if (combatFocusPan) canvas.animatePan({ x: currentToken.center.x, y: currentToken.center.y, duration: 250 });
 
         if (combatFocusPostion !== "0") {

--- a/src/combatFocus.js
+++ b/src/combatFocus.js
@@ -13,7 +13,7 @@ Hooks.on('init', () => {
         scope: 'world',
         type: String,
         choices: {
-            "0": "Off",
+            "0": "Disable opening character sheet",
             "1": "Top Left",
             "2": "Top Right",
         },
@@ -57,12 +57,21 @@ Hooks.on('init', () => {
         default: "0",
         config: true,
     });
+    game.settings.register("Next-Up", "removePin", {
+        name: 'Remove Pin Icon From Character Sheets',
+        scope: 'world',
+        type: Boolean,
+        default: false,
+        config: true,
+    });
 
 
 
 })
 
 Hooks.on("renderActorSheet", (app, html, data) => {
+    if (game.settings.get("Next-Up", "removePin")) return;
+
     let title = html.find('.window-title');
     let buttons = `
 <button id="nextup-pin" class="nextup-button" title="Pin Actor Sheet" style="height:30px;width:30px">
@@ -83,9 +92,10 @@ Hooks.on("renderActorSheet", (app, html, data) => {
         }
 
     })
-})
+});
+
 let delay = 5;
-if (typeof ForgeVTT !== 'undefined') delay = 15
+if (typeof ForgeVTT !== 'undefined') delay = 15;
 
 Hooks.on("updateCombat", async (combat, changed, options, userId) => {
 
@@ -125,10 +135,10 @@ Hooks.on("updateCombat", async (combat, changed, options, userId) => {
         const combatFocusType = game.settings.get('Next-Up', 'combatFocusType')
         let currentWindows = Object.values(ui.windows)
 
+        await sleep(delay);
+        await currentToken.control();
+        if (combatFocusPan) canvas.animatePan({ x: currentToken.center.x, y: currentToken.center.y, duration: 250 });
         if (combatFocusPostion !== "0") {
-            await sleep(delay);
-            await currentToken.control();
-            if (combatFocusPan) canvas.animatePan({ x: currentToken.center.x, y: currentToken.center.y, duration: 250 });
             let currentSheet = currentWindows.filter(i => i.token?.id === currentToken.id);
             let sheet;
             if (currentSheet.length === 0)
@@ -160,6 +170,7 @@ Hooks.on("updateCombat", async (combat, changed, options, userId) => {
                 }
             }
         }
+
         switch (closeWhich) {
             case "0": break;
             case "1": {


### PR DESCRIPTION
Adds setting to remove pin icon from character sheets.
Adds logic for canvas panning without opening character sheet.
Adds setting to enable player panning, but canvas will not pan if next combatant is not visible to player (either by lack of LOS or hidden token).

Only hiccup I came across in my testing is that there would sometimes be a delay in between the character sheet rendering and being moved into the appropriate corner.

enso#0361